### PR TITLE
Work with standard file layout

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -107,7 +107,7 @@ func main() {
 			sourceFileMap[file] = sourceFile
 			f, err := os.Open(file)
 			if err != nil {
-				continue
+				log.Fatal(err)
 			}
 			b, err := ioutil.ReadAll(f)
 			if err == nil {


### PR DESCRIPTION
I was getting incorrect behavior from `goveralls` because it was expecting this kind of file layout:

```
$GOPATH/
  src/
    foobar/
      foobar.go
```

Whereas I use this kind of file layout, which is increasingly "standard" in the community:

```
$GOPATH/
  src/
    github.com/
      jmcvetta/
        foobar/
          foobar.go
```

This problem was fixed by changing a regular expression.

Also make `goveralls` exit with an error if it cannot open a source file, such as could happen if user runs it from somewhere other than the package directory.
