### PR TITLE
Bugfix and several improvements

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -115,7 +115,9 @@ func collectGitInfo() *Git {
 		if err != nil {
 			log.Fatal(err)
 		}
-		results[key] = string(ret)
+		s := string(ret)
+		s = strings.TrimRight(s, "\n")
+		results[key] = s
 	}
 	for _, line := range strings.Split(results["remotes"], "\n") {
 		matches := remotesRE.FindAllStringSubmatch(line, -1)


### PR DESCRIPTION
- In coverage data for files >=100 lines, `goveralls` was skipping lines 1-99 because they started with a leading space.  Fixed this with a regular expression.
- Send git commit details to coveralls.io.
- Use `flag` package to handle options.
