### PR TITLE
When running annotate, make sure we only see the function we want.

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -238,7 +238,7 @@ func main() {
 		if len(matches) == 0 {
 			continue
 		}
-		cmd = exec.Command("gocov", "annotate", "-", matches[0][1]+"."+matches[0][3])
+		cmd = exec.Command("gocov", "annotate", "-", "^"+matches[0][1]+"."+matches[0][3]+"$")
 		cmd.Stderr = os.Stderr
 		cmd.Stdin = strings.NewReader(covret)
 		ret, err = cmd.Output()


### PR DESCRIPTION
gocov annotate takes a regexp as input, not the function required.  Thus
if a function is a prefix for another in the same package, both will be
returned.  At the minimum, this will cause an incorrect report.  If the
second function's line number is outside the range of the original function's
source file's line numbers, the program will panic.  Fix by using a regexp
to force the exact string to match.
