### PR TITLE
Handle autogenerated code better

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -261,7 +261,8 @@ func main() {
 			if !ok {
 				b, err = ioutil.ReadFile(fun.File)
 				if err != nil {
-					log.Fatalf("Error reading %v: %v", fun.File, err)
+					log.Printf("Error reading %v: %v (skipping)", fun.File, err)
+					continue
 				}
 				fileContent[fun.File] = b
 				// Count the lines


### PR DESCRIPTION
I had some autogenerated code that was missing a newline or simply referencing files that never existed.  This allows them to be included in coverage reports.

Also, I did a lot of the testing offline, so I made the empty token output include the API request for inspection.  That can be conditional, of course, but it really makes it easier to see what's going on.
