### PR TITLE
repo name incorrect, last patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ test suite.
 ## Travis CI
 
     go get code.google.com/p/go.tools/cmd/cover
-    go get github.com/hailiang/goveralls
+    go get github.com/mattn/goveralls
     go test -covermode=count -coverprofile=profile.cov
     goveralls -coverprofile=profile.cov -service=travis-ci
 


### PR DESCRIPTION
Typo in README under travis, wrong repoistory

go get github.com/hailiang/goveralls

but should be

go get github.com/mattn/goveralls
