### PR TITLE
Send correct source code filename to Coveralls

### DIFF
--- a/gocov.go
+++ b/gocov.go
@@ -79,7 +79,7 @@ func parseGocov(cov io.ReadCloser) ([]*SourceFile, error) {
 				fileContent[fun.File] = b
 				// Count the lines
 				sf := &SourceFile{
-					Name:     fun.File,
+					Name:     getCoverallsSourceFileName(fun.File),
 					Source:   string(b),
 					Coverage: make([]interface{}, bytes.Count(b, []byte{'\n'})),
 				}

--- a/gocover.go
+++ b/gocover.go
@@ -130,7 +130,7 @@ func parseCover(fn string) []*SourceFile {
 			log.Fatalf("Error reading %v: %v", path, err)
 		}
 		sf := &SourceFile{
-			Name:     prof.FileName,
+			Name:     getCoverallsSourceFileName(path),
 			Source:   string(fb),
 			Coverage: make([]interface{}, 1+bytes.Count(fb, []byte{'\n'})),
 		}

--- a/goveralls.go
+++ b/goveralls.go
@@ -75,6 +75,30 @@ func getCoverage() []*SourceFile {
 	}
 }
 
+var vscDirs = []string{".git", ".hg", ".bzr", ".svn"}
+
+func findRepositoryRoot(dir string) (string, bool) {
+	for _, vcsdir := range vscDirs {
+		if d, err := os.Stat(filepath.Join(dir, vcsdir)); err == nil && d.IsDir() {
+			return dir, true
+		}
+	}
+	nextdir := filepath.Dir(dir)
+	if nextdir == dir {
+		return "", false
+	}
+	return findRepositoryRoot(nextdir)
+}
+
+func getCoverallsSourceFileName(name string) string {
+	if dir, ok := findRepositoryRoot(name); !ok {
+		return name
+	} else {
+		filename := strings.TrimPrefix(name, dir+string(os.PathSeparator))
+		return filename
+	}
+}
+
 func main() {
 	log.SetFlags(log.Ltime | log.Lshortfile)
 	//


### PR DESCRIPTION
This is so that the source code for the file will appear in their coverage report.

The change currently only affects github.com repositories.
