### PR TITLE
Allow Cover to work for different versions of Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ go:
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
     - $HOME/gopath/bin/goveralls -repotoken lAKAWPzcGsD3A8yBX3BGGtRUdJ6CaGERL
 ```


### PR DESCRIPTION
Avoids:

```
$ go get code.google.com/p/go.tools/cmd/cover
the code.google.com/p/go.tools/cmd/cover command has moved; use golang.org/x/tools/cmd/cover instead.
```
