### PR TITLE
Prevent Travis failure on coveralls.io server internal errors

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -163,7 +163,7 @@ func process() error {
 		return fmt.Errorf("Unable to read response body from coveralls: %s", err)
 	}
 
-	if res.StatusCode >= http.StatusInternalServerError && shallow {
+	if res.StatusCode >= http.StatusInternalServerError && *shallow {
 		fmt.Println("coveralls.io failed internally")
 		return nil
 	}

--- a/goveralls.go
+++ b/goveralls.go
@@ -161,6 +161,12 @@ func process() error {
 	if err != nil {
 		return fmt.Errorf("Unable to read response body from coveralls: %s", err)
 	}
+
+	if res.StatusCode >= http.StatusInternalServerError {
+		fmt.Println("coverall.io failed internally")
+		return nil
+	}
+
 	if res.StatusCode != 200 {
 		return fmt.Errorf("Bad response status from coveralls: %d - %s", res.StatusCode, string(bodyBytes))
 	}

--- a/goveralls.go
+++ b/goveralls.go
@@ -35,6 +35,7 @@ var (
 	covermode = flag.String("covermode", "count", "sent as covermode argument to gocov if applicable")
 	repotoken = flag.String("repotoken", "", "Repository Token on coveralls")
 	service   = flag.String("service", "travis-ci", "The CI service or other environment in which the test suite was run. ")
+	shallow   = flag.Bool("shallow", false, "Shallow coveralls.io internal server errors")
 )
 
 // usage supplants package flag's Usage variable
@@ -162,8 +163,8 @@ func process() error {
 		return fmt.Errorf("Unable to read response body from coveralls: %s", err)
 	}
 
-	if res.StatusCode >= http.StatusInternalServerError {
-		fmt.Println("coverall.io failed internally")
+	if res.StatusCode >= http.StatusInternalServerError && shallow {
+		fmt.Println("coveralls.io failed internally")
 		return nil
 	}
 


### PR DESCRIPTION
coveralls.io occasionally fails with a 504 status code despite the coverage report being uploaded.  This causes the travis build to fail even though the tests all passed and the coverage report was uploaded. Clicking the rebuild button on Travis until coveralls.io accepts the coverage will resolve this issue.  This pull requests adds a flag to ignore returns from coveralls.io that are status 500s.  Allowing the Travis build to succeed even when coveralls.io is under heavy load.