### PR TITLE
Make -repotoken default to $COVERALLS_TOKEN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ $ cd $GOPATH/src/github.com/yourusername/yourpackage
 $ goveralls -repotoken your_repos_coveralls_token
 ```
 
+You can set the environment variable `$COVERALLS_TOKEN` to your token so you do
+not have to specify it at each invocation.
+
 # Continuous Integration
 
 There is no need to run `go test` separately, as `goveralls` runs the entire
@@ -60,8 +63,15 @@ before_install:
   - go get github.com/mattn/goveralls
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 script:
-    - $HOME/gopath/bin/goveralls -repotoken lAKAWPzcGsD3A8yBX3BGGtRUdJ6CaGERL
+    - $HOME/gopath/bin/goveralls
 ```
+
+Store your Coveralls API token in `Environment variables`.
+
+```
+COVERALLS_TOKEN = your_token_goes_here
+```
+
 
 ### For others:
 
@@ -74,7 +84,7 @@ $ goveralls -coverprofile=profile.cov -service=travis-ci
 
 ## Drone.io
 
-Store your Coveralls API token in `Enviornment Variables`:
+Store your Coveralls API token in `Environment Variables`:
 
 ```
 COVERALLS_TOKEN=your_token_goes_here
@@ -85,13 +95,16 @@ Replace the `go test` line in your `Commands` with these lines:
 ```
 $ go get github.com/axw/gocov/gocov
 $ go get github.com/mattn/goveralls
-$ goveralls -service drone.io -repotoken $COVERALLS_TOKEN
+$ goveralls -service drone.io
 ```
+
+`goveralls` automatically use the environment variable `COVERALLS_TOKEN` as the
+default value for `-repotoken`.
 
 You can use the `-v` flag to see verbose output from the test suite:
 
 ```
-$ goveralls -v -service drone.io -repotoken $COVERALLS_TOKEN
+$ goveralls -v -service drone.io
 ```
 
 For more information, See https://coveralls.io/docs/go

--- a/goveralls.go
+++ b/goveralls.go
@@ -34,7 +34,7 @@ var (
 	gocovjson = flag.String("gocovdata", "", "If supplied, use existing gocov.json")
 	coverprof = flag.String("coverprofile", "", "If supplied, use a go cover profile")
 	covermode = flag.String("covermode", "count", "sent as covermode argument to gocov if applicable")
-	repotoken = flag.String("repotoken", "", "Repository Token on coveralls")
+	repotoken = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls; defaults to $COVERALLS_TOKEN if set")
 	service   = flag.String("service", "travis-ci", "The CI service or other environment in which the test suite was run. ")
 	shallow   = flag.Bool("shallow", false, "Shallow coveralls.io internal server errors")
 )


### PR DESCRIPTION
This simplifies management on CI. Settings the environment variable in the CI
system is sufficient, no need to change the command line arguments. Since it's
only setting the default value, specifying the -repotoken flag will safely
override the default value.

Update the doc to recommend using $COVERALLS_TOKEN by default.