### PR TITLE
Fix for error "x509: certificate signed by unknown authority"

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	_ "crypto/sha512"
 	"encoding/json"
 	"errors"
 	"flag"


### PR DESCRIPTION
Today I spent half an hour trying to debug the following error

    x509: certificate signed by unknown authority (possibly because of "x509: cannot verify signature: algorithm unimplemented" while trying to verify candidate authority certificate "COMODO ECC Certification Authority"

The build for https://travis-ci.org/weppos/go-dnsimple suddently stopped to work and it always returned the error above for go 1.2 on Travis (you can check the build logs).

I tried to update the CA list on the machine, but it didn't work. The fix described in https://github.com/schachmat/wego/pull/49 instead it worked and it allowed the build to pass. This PR includes the same fix.