### PR TITLE
Adds -ignore flag to filter files that shouldn't be uploaded to coveralls

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -168,6 +168,9 @@ func process() error {
 	// Ignore files
 	if len(*ignore) > 0 {
 		patterns := strings.Split(*ignore, ",")
+		for i, pattern := range patterns {
+			patterns[i] = strings.TrimSpace(pattern)
+		}
 		var files []*SourceFile
 	Files:
 		for _, file := range j.SourceFiles {


### PR DESCRIPTION
In a number of projects, I have protocol buffers that are automatically compiled into Go. It doesn't make sense to waste effort adding tests to them, but it would also be nice for it to not affect the coveralls report.

This PR adds a `-ignore` flag that allows you to specify comma separated ignore globs. This makes it so you can do stuff like `goveralls -ignore="**/*.pb.go"`.

Thanks!