### PR TITLE
Fix undercounting of coverage for lines in multiple blocks.

### DIFF
--- a/gocover.go
+++ b/gocover.go
@@ -137,7 +137,8 @@ func parseCover(fn string) []*SourceFile {
 
 		for _, block := range prof.Blocks {
 			for i := block.StartLine; i <= block.EndLine; i++ {
-				sf.Coverage[i-1] = block.Count
+				count, _ := sf.Coverage[i-1].(int)
+				sf.Coverage[i-1] = count + block.Count
 			}
 		}
 


### PR DESCRIPTION
The coverprofile format uses both lines and columns. It can report coverage for the same line across multiple blocks, if the column ranges do not overlap. The coverage counts should be summed, not assigned.

Here is an example:

c.go
```
package c

func False() bool { return false }

func F() int {
	if False() {
		return 1
	}
	return 2
}
```

c_test.go
```
package c

import "testing"

func TestF(t *testing.T) { F() }

```

The `return 1` is never tested, but the call to `False()` is tested.

The coverprofile is:
```
mode: set
test/c/c.go:3.19,3.35 1 1
test/c/c.go:5.14,6.13 1 1
test/c/c.go:9.2,9.10 1 1
test/c/c.go:6.13,8.3 1 0
```

Line 6, the condition of the if-statement, is accounted for in two blocks. The first refers to the statement `False()`, the second refers to the beginning `{` of the block. The count of 0 for the un-covered `return 1` was over-writing the count of 1 for the covered `False()`, causing the coverage to be under-counted.

Fixes #61