### PR TITLE
Update CircleCI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ test:
   override:
     - go test -v -cover -race -coverprofile=/home/ubuntu/coverage.out
   post:
-    - /home/ubuntu/bin/goveralls -coverprofile=/home/ubuntu/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+    - /home/ubuntu/.go_workspace/bin/goveralls -coverprofile=/home/ubuntu/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 ```
 
 For more information, See https://coveralls.zendesk.com/hc/en-us/articles/201342809-Go


### PR DESCRIPTION
Awesome integration, thanks for making this!

Just had to make one small tweak to the CircleCI example to get it to work. (Couldn't find the goveralls executable before)

https://circleci.com/docs/language-go/#dependencies

> By default, CircleCI will run go get to retrieve all of your project’s
> dependencies. This means that any dependency that exists as an import
> within the source code will be brought in. These packages are stored
> within the Go Workspace (/home/ubuntu/.go_workspace), which is a cached
> directory. This means that in future builds, packages that haven’t
> changed don’t need to be re-downloaded, which saves build time.