### PR TITLE
Support multiple-packages 

### DIFF
--- a/gocover.go
+++ b/gocover.go
@@ -38,7 +38,7 @@ func mergeProfs(pfss [][]*cover.Profile) []*cover.Profile {
 			break
 		}
 	}
-	if len(pfss) < 1 {
+	if len(pfss) == 0 {
 		return nil
 	} else if len(pfss) == 1 {
 		return pfss[0]
@@ -47,7 +47,7 @@ func mergeProfs(pfss [][]*cover.Profile) []*cover.Profile {
 	ret := make([]*cover.Profile, 0, len(head))
 	for i, profile := range head {
 		for _, ps := range rest {
-			if len(ps) < 1 {
+			if len(ps) == 0 {
 				// no test files
 				continue
 			} else if len(ps) < i+1 {

--- a/gocover.go
+++ b/gocover.go
@@ -28,12 +28,51 @@ func findFile(file string) (string, error) {
 	return filepath.Join(pkg.Dir, file), nil
 }
 
-func parseCover(fn string) ([]*SourceFile, error) {
-	profs, err := cover.ParseProfiles(fn)
-	if err != nil {
-		return nil, fmt.Errorf("Error parsing coverage: %v", err)
+// mergeProfs merges profiles for same target packages.
+// It assumes each profiles have same sorted FileName and Blocks.
+func mergeProfs(pfss [][]*cover.Profile) []*cover.Profile {
+	if len(pfss) < 1 {
+		return nil
+	} else if len(pfss) == 1 {
+		return pfss[0]
 	}
+	head, rest := pfss[0], pfss[1:]
+	ret := make([]*cover.Profile, 0, len(head))
+	for i, profile := range head {
+		for _, ps := range rest {
+			if len(ps) < i+1 {
+				log.Fatal("Profile length is different")
+			}
+			if ps[i].FileName != profile.FileName {
+				log.Fatal("Profile FileName is different")
+			}
+			profile.Blocks = mergeProfBlocks(profile.Blocks, ps[i].Blocks)
+		}
+		ret = append(ret, profile)
+	}
+	return ret
+}
 
+func mergeProfBlocks(as, bs []cover.ProfileBlock) []cover.ProfileBlock {
+	if len(as) != len(bs) {
+		log.Fatal("Two block length should be same")
+	}
+	// cover.ProfileBlock genereated by cover.ParseProfiles() is sorted by
+	// StartLine and StartCol, so we can use index.
+	ret := make([]cover.ProfileBlock, 0, len(as))
+	for i, a := range as {
+		b := bs[i]
+		if a.StartLine != b.StartLine || a.StartCol != b.StartCol {
+			log.Fatal("Blocks are not sorted")
+		}
+		a.Count += b.Count
+		ret = append(ret, a)
+	}
+	return ret
+}
+
+// toSF converts profiles to sourcefiles for coveralls.
+func toSF(profs []*cover.Profile) ([]*SourceFile, error) {
 	var rv []*SourceFile
 	for _, prof := range profs {
 		path, err := findFile(prof.FileName)
@@ -61,4 +100,12 @@ func parseCover(fn string) ([]*SourceFile, error) {
 	}
 
 	return rv, nil
+}
+
+func parseCover(fn string) ([]*SourceFile, error) {
+	profs, err := cover.ParseProfiles(fn)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing coverage: %v", err)
+	}
+	return toSF(profs)
 }

--- a/gocover.go
+++ b/gocover.go
@@ -40,7 +40,10 @@ func mergeProfs(pfss [][]*cover.Profile) []*cover.Profile {
 	ret := make([]*cover.Profile, 0, len(head))
 	for i, profile := range head {
 		for _, ps := range rest {
-			if len(ps) < i+1 {
+			if len(ps) < 1 {
+				// no test files
+				continue
+			} else if len(ps) < i+1 {
 				log.Fatal("Profile length is different")
 			}
 			if ps[i].FileName != profile.FileName {

--- a/gocover.go
+++ b/gocover.go
@@ -31,6 +31,13 @@ func findFile(file string) (string, error) {
 // mergeProfs merges profiles for same target packages.
 // It assumes each profiles have same sorted FileName and Blocks.
 func mergeProfs(pfss [][]*cover.Profile) []*cover.Profile {
+	// skip empty profiles ([no test files])
+	for i := 0; i < len(pfss); i++ {
+		if len(pfss[i]) > 0 {
+			pfss = pfss[i:]
+			break
+		}
+	}
 	if len(pfss) < 1 {
 		return nil
 	} else if len(pfss) == 1 {

--- a/gocover_test.go
+++ b/gocover_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"golang.org/x/tools/cover"
+)
+
+func TestMergeProfs(t *testing.T) {
+	tests := []struct {
+		in   [][]*cover.Profile
+		want []*cover.Profile
+	}{
+		// empty
+		{in: nil, want: nil},
+		// The number of profiles is 1
+		{in: [][]*cover.Profile{[]*cover.Profile{{FileName: "name1"}}}, want: []*cover.Profile{{FileName: "name1"}}},
+		// merge profile blocks
+		{
+			in: [][]*cover.Profile{
+				[]*cover.Profile{}, // skip first empty profiles.
+				[]*cover.Profile{
+					{
+						FileName: "name1",
+						Blocks: []cover.ProfileBlock{
+							cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 1},
+						},
+					},
+					{
+						FileName: "name2",
+						Blocks: []cover.ProfileBlock{
+							cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 0},
+						},
+					},
+				},
+				[]*cover.Profile{}, // skip first empty profiles.
+				[]*cover.Profile{
+					{
+						FileName: "name1",
+						Blocks: []cover.ProfileBlock{
+							cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 1},
+						},
+					},
+					{
+						FileName: "name2",
+						Blocks: []cover.ProfileBlock{
+							cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 1},
+						},
+					},
+				},
+			},
+			want: []*cover.Profile{
+				{
+					FileName: "name1",
+					Blocks: []cover.ProfileBlock{
+						cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 2},
+					},
+				},
+				{
+					FileName: "name2",
+					Blocks: []cover.ProfileBlock{
+						cover.ProfileBlock{StartLine: 1, StartCol: 1, Count: 1},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		if got := mergeProfs(tt.in); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("mergeProfs(%#v) = %#v, want %#v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/goveralls.go
+++ b/goveralls.go
@@ -80,8 +80,11 @@ type Response struct {
 
 // getPkgs returns packages for mesuring coverage. Returned packages doesn't
 // contain vendor packages.
-func getPkgs() ([]string, error) {
-	out, err := exec.Command("go", "list", "./...").CombinedOutput()
+func getPkgs(pkg string) ([]string, error) {
+	if pkg == "" {
+		pkg = "./..."
+	}
+	out, err := exec.Command("go", "list", pkg).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +103,8 @@ func getCoverage() ([]*SourceFile, error) {
 		return parseCover(*coverprof)
 	}
 
-	pkgs, err := getPkgs()
+	// pkgs is packages to run tests and get coverage.
+	pkgs, err := getPkgs(*pkg)
 	if err != nil {
 		return nil, err
 	}
@@ -120,9 +124,6 @@ func getCoverage() ([]*SourceFile, error) {
 		}
 		args = append(args, line)
 		args = append(args, flag.Args()...)
-		if *pkg != "" {
-			args = append(args, *pkg)
-		}
 		cmd.Args = args
 		b, err := cmd.CombinedOutput()
 		if err != nil {

--- a/goveralls.go
+++ b/goveralls.go
@@ -83,7 +83,7 @@ func getList() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(string(out), "\n"), nil
+	return strings.Split(strings.Trim(string(out), "\n"), "\n"), nil
 }
 
 func getCoverage() ([]*SourceFile, error) {

--- a/goveralls.go
+++ b/goveralls.go
@@ -47,7 +47,7 @@ var (
 var usage = func() {
 	cmd := os.Args[0]
 	// fmt.Fprintf(os.Stderr, "Usage of %s:\n", cmd)
-	s := "Usage: %s [options] TOKEN\n"
+	s := "Usage: %s [options]\n"
 	fmt.Fprintf(os.Stderr, s, cmd)
 	flag.PrintDefaults()
 }
@@ -123,7 +123,6 @@ func getCoverage() ([]*SourceFile, error) {
 			args = append(args, "-v")
 		}
 		args = append(args, line)
-		args = append(args, flag.Args()...)
 		cmd.Args = args
 		b, err := cmd.CombinedOutput()
 		if err != nil {
@@ -179,6 +178,10 @@ func process() error {
 	//
 	flag.Usage = usage
 	flag.Parse()
+	if len(flag.Args()) > 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
 
 	//
 	// Setup PATH environment variable

--- a/goveralls_test.go
+++ b/goveralls_test.go
@@ -24,6 +24,20 @@ func TestUsage(t *testing.T) {
 	}
 }
 
+func TestInvalidArg(t *testing.T) {
+	tmp := prepareTest(t)
+	defer os.RemoveAll(tmp)
+	cmd := exec.Command("goveralls", "pkg")
+	b, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("Expected exit code 1 bot 0")
+	}
+	s := strings.Split(string(b), "\n")[0]
+	if !strings.HasPrefix(s, "Usage: goveralls ") {
+		t.Fatalf("Expected %v, but %v", "Usage: ", s)
+	}
+}
+
 func TestGoveralls(t *testing.T) {
 	wd, _ := os.Getwd()
 	tmp := prepareTest(t)
@@ -44,8 +58,7 @@ func TestGoveralls(t *testing.T) {
 func prepareTest(t *testing.T) (tmpPath string) {
 	tmp := os.TempDir()
 	tmp = filepath.Join(tmp, uuid.New())
-	os.Setenv("GOPATH", tmp)
-	runCmd(t, "go", "get", "github.com/mattn/goveralls")
+	runCmd(t, "go", "build", "-o", filepath.Join(tmp, "bin", "goveralls"), "github.com/mattn/goveralls")
 	os.Setenv("PATH", filepath.Join(tmp, "bin")+string(filepath.ListSeparator)+os.Getenv("PATH"))
 	os.MkdirAll(filepath.Join(tmp, "src"), 0755)
 	return tmp


### PR DESCRIPTION
ref: https://github.com/mattn/goveralls/issues/68 https://github.com/mattn/goveralls/issues/20

I created branch based on de5a843 to support run coverage for multiple packages.

de5a843 has some problem and this p-r fixes them.

### What this p-r did
- support `-coverpkgs` arg to run coverage for all packages, not only for packages to run test.
  - example: https://github.com/haya14busa/go-cover-multi-pkgs-example/pull/1
- support `-package` arg for backword compatibility
  - example: https://coveralls.io/builds/7837950 https://github.com/haya14busa/go-cover-multi-pkgs-example/pull/3#issuecomment-246214508
- merge coverprofile's into one profile before sending to coveralls.
  - just sending all coverprofiles turns coverage to 100%, but sourcefiles contains duplicated files. https://github.com/haya14busa/go-cover-multi-pkgs-example/pull/2#issuecomment-246208492
- do not allow extra arguments https://github.com/mattn/goveralls/commit/1fe178dd7c29c51477cb12165777a3bd151e73f6 for compatibility.
  - Now, we cannot handle `goveralls pkg`. The users should use `-package` arg instead (`goveralls -package pkg`). `TOKEN` arg seems deprecated and the users should use `-repotoken`.
- ignore vendor directories.

working example: https://github.com/haya14busa/go-cover-multi-pkgs-example/pull/3

I guess I should write more tests, but it works perfectly for me.

I read https://github.com/golang/go/issues/6909#issuecomment-233493644 issue and tries to write a patch to golang at first,
but we cannot support `-coverprofile` with multiple packages without drastic interface changes (like changes -coverprofile format, etc..), imo.

So, I decided to crate this p-r.

What do you think?