### PR TITLE
Output to stdout on vebose

### DIFF
--- a/goveralls_test.go
+++ b/goveralls_test.go
@@ -1,14 +1,25 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/pborman/uuid"
 )
+
+func fakeServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, `{"error":false,"message":"Fake message","URL":"http://fake.url"}`)
+	}))
+}
 
 func TestUsage(t *testing.T) {
 	tmp := prepareTest(t)
@@ -36,6 +47,38 @@ func TestInvalidArg(t *testing.T) {
 	if !strings.HasPrefix(s, "Usage: goveralls ") {
 		t.Fatalf("Expected %v, but %v", "Usage: ", s)
 	}
+}
+
+func TestVerboseArg(t *testing.T) {
+	tmp := prepareTest(t)
+	defer os.RemoveAll(tmp)
+	fs := fakeServer()
+
+	t.Run("with verbose", func(t *testing.T) {
+		cmd := exec.Command("goveralls", "-package=github.com/mattn/goveralls/tester", "-v", "-endpoint")
+		cmd.Args = append(cmd.Args, "-v", "-endpoint", fs.URL)
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal("Expected exit code 0 got 1", err, string(b))
+		}
+
+		if !strings.Contains(string(b), "--- PASS") {
+			t.Error("Expected to have verbosed go test output in stdout", string(b))
+		}
+	})
+
+	t.Run("without verbose", func(t *testing.T) {
+		cmd := exec.Command("goveralls", "-package=github.com/mattn/goveralls/tester", "-endpoint")
+		cmd.Args = append(cmd.Args, "-v", "-endpoint", fs.URL)
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal("Expected exit code 0 got 1", err, string(b))
+		}
+
+		if strings.Contains(string(b), "--- PASS") {
+			t.Error("Expected to haven't verbosed go test output in stdout", string(b))
+		}
+	})
 }
 
 /* FIXME: currently this dones't work because the command goveralls will run


### PR DESCRIPTION
I would like to see `go test -v` actual output, when passing `-v` flag to `goveralls`

![goverall_output](https://api.monosnap.com/rpc/file/download?id=NU8f2zSHMnh5S8rugZ8hqD6KaHCjt7)