### PR TITLE
Add race detection support with atomic

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -45,6 +45,7 @@ var (
 	extraFlags Flags
 	pkg        = flag.String("package", "", "Go package")
 	verbose    = flag.Bool("v", false, "Pass '-v' argument to 'go test' and output to stdout")
+	race       = flag.Bool("race", false, "Pass '-race' argument to 'go test'")
 	debug      = flag.Bool("debug", false, "Enable debug output")
 	coverprof  = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
 	covermode  = flag.String("covermode", "count", "sent as covermode argument to go test")
@@ -132,11 +133,17 @@ func getCoverage() ([]*SourceFile, error) {
 		outBuf := new(bytes.Buffer)
 		cmd.Stdout = outBuf
 		cmd.Stderr = outBuf
-
-		args := []string{"go", "test", "-covermode", *covermode, "-coverprofile", f.Name(), coverpkg}
+		coverm := *covermode
+		if *race {
+			coverm = "atomic"
+		}
+		args := []string{"go", "test", "-covermode", coverm, "-coverprofile", f.Name(), coverpkg}
 		if *verbose {
 			args = append(args, "-v")
 			cmd.Stdout = os.Stdout
+		}
+		if *race {
+			args = append(args, "-race")
 		}
 		args = append(args, extraFlags...)
 		args = append(args, line)

--- a/goveralls_test.go
+++ b/goveralls_test.go
@@ -41,7 +41,7 @@ func TestInvalidArg(t *testing.T) {
 	cmd := exec.Command("goveralls", "pkg")
 	b, err := cmd.CombinedOutput()
 	if err == nil {
-		t.Fatal("Expected exit code 1 bot 0")
+		t.Fatal("Expected exit code 1 got 0")
 	}
 	s := strings.Split(string(b), "\n")[0]
 	if !strings.HasPrefix(s, "Usage: goveralls ") {
@@ -77,6 +77,21 @@ func TestVerboseArg(t *testing.T) {
 
 		if strings.Contains(string(b), "--- PASS") {
 			t.Error("Expected to haven't verbosed go test output in stdout", string(b))
+		}
+	})
+}
+
+func TestRaceArg(t *testing.T) {
+	tmp := prepareTest(t)
+	defer os.RemoveAll(tmp)
+	fs := fakeServer()
+
+	t.Run("it should pass the test", func(t *testing.T) {
+		cmd := exec.Command("goveralls", "-package=github.com/mattn/goveralls/tester", "-race")
+		cmd.Args = append(cmd.Args, "-endpoint", fs.URL)
+		b, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal("Expected exit code 0 got 1", err, string(b))
 		}
 	})
 }


### PR DESCRIPTION
According to https://github.com/golang/go/issues/12118, `-race` could be used with `-covermode` flag but with `atomic` option.