### PR TITLE
Examples in README now use $GOPATH instead of $HOME/gopath

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go:
 before_install:
   - go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - $GOPATH/bin/goveralls -service=travis-ci
 ```
 
 For a **public** github repository, it is not necessary to define your repository key (`COVERALLS_TOKEN`).
@@ -63,7 +63,7 @@ go:
 before_install:
   - go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-pro
+  - $GOPATH/bin/goveralls -service=travis-pro
 ```
 
 Store your Coveralls API token in `Environment variables`.


### PR DESCRIPTION
The examples did not work for people with different GOPATH setup than $HOME/gopath.

If you have access please also note [this page](https://coveralls.zendesk.com/hc/en-us/articles/201342809-Go) could be fixed accordingly.