### PR TITLE
Added support to Jenkins CI

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -249,6 +249,8 @@ func process() error {
 		jobId = appveyorJobId
 	} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
 		jobId = semaphoreJobId
+	} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
+		jobId = jenkinsJobId
 	}
 
 	if *repotoken == "" {


### PR DESCRIPTION
In a Jenkins CI server, goveralls can't determine the Build Number because it's not implemented. This cause that Coveralls.io update multiple times the first build because it's stuck in the build 1.

Added imp. for Jenkins environment variable $BUILD_NUMBER