### PR TITLE
Add WERCKER_GIT_BRANCH for wercker CI

### DIFF
--- a/gitinfo.go
+++ b/gitinfo.go
@@ -106,7 +106,7 @@ func collectGitInfo() *Git {
 }
 
 func loadBranchFromEnv() string {
-	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH"}
+	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH"}
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
 			return branch

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -19,6 +19,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"TRAVIS_BRANCH":        "travis-master",
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
+				"WERCKER_GIT_BRANCH":   "wercker-master",
 			},
 			"master",
 		},
@@ -29,6 +30,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"TRAVIS_BRANCH":        "travis-master",
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
+				"WERCKER_GIT_BRANCH":   "wercker-master",
 			},
 			"circle-master",
 		},
@@ -38,6 +40,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"TRAVIS_BRANCH":        "travis-master",
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
+				"WERCKER_GIT_BRANCH":   "wercker-master",
 			},
 			"travis-master",
 		},
@@ -56,6 +59,13 @@ func TestLoadBranchFromEnv(t *testing.T) {
 			"appveyor-master",
 		},
 		{
+			"only WERCKER_GIT_BRANCH defined",
+			map[string]string{
+				"WERCKER_GIT_BRANCH": "wercker-master",
+			},
+			"wercker-master",
+		},
+		{
 			"no branch var defined",
 			map[string]string{},
 			"",
@@ -71,7 +81,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 }
 
 func resetBranchEnvs(values map[string]string) {
-	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH"} {
+	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH"} {
 		os.Unsetenv(envVar)
 	}
 	for k, v := range values {


### PR DESCRIPTION
Add support for [wercker](http://www.wercker.com/).

In wercker build, no `GIT_BRANCH` defined and `WERCKER_GIT_BRANCH` defined.
This PR allowed to get automatically git branch from `WERCKER_GIT_BRANCH` environment variable.