### PR TITLE
Support parallel test coverage uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ $ goveralls -repotoken your_repos_coveralls_token
 You can set the environment variable `$COVERALLS_TOKEN` to your token so you do
 not have to specify it at each invocation.
 
+
+You can also run this reporter for multiple passes with the flag `-parallel` or
+by setting the environment variable `COVERALLS_PARALLEL=true` (see [coveralls
+docs](https://docs.coveralls.io/parallel-build-webhook) for more details.
+
+
 # Continuous Integration
 
 There is no need to run `go test` separately, as `goveralls` runs the entire

--- a/goveralls.go
+++ b/goveralls.go
@@ -51,6 +51,7 @@ var (
 	coverprof  = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
 	covermode  = flag.String("covermode", "count", "sent as covermode argument to go test")
 	repotoken  = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls")
+	parallel   = flag.Bool("parallel", os.Getenv("COVERALLS_PARALLEL") != "", "Submit as parallel")
 	endpoint   = flag.String("endpoint", "https://coveralls.io", "Hostname to submit Coveralls data to")
 	service    = flag.String("service", "travis-ci", "The CI service or other environment in which the test suite was run. ")
 	shallow    = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
@@ -83,6 +84,7 @@ type Job struct {
 	ServicePullRequest string        `json:"service_pull_request,omitempty"`
 	ServiceName        string        `json:"service_name"`
 	SourceFiles        []*SourceFile `json:"source_files"`
+	Parallel           *bool         `json:"parallel,omitempty"`
 	Git                *Git          `json:"git,omitempty"`
 	RunAt              time.Time     `json:"run_at"`
 }
@@ -280,6 +282,7 @@ func process() error {
 		RunAt:              time.Now(),
 		RepoToken:          repotoken,
 		ServicePullRequest: pullRequest,
+		Parallel:           parallel,
 		Git:                collectGitInfo(),
 		SourceFiles:        sourceFiles,
 	}


### PR DESCRIPTION
This PR adds support for parallel coverage reporting. Please let me know if there's anything here that I could improve or that you'd like to see changed and I'd be happy to do so!

In order to allow for parallel test runs reporting in coverage information, we need to pass in a `parallel` boolean in our job object (see API docs here https://docs.coveralls.io/api-reference).

The caveat here is that this means we'll have to hit a webhook after all parallel workers have completed, as per the documentation provided in the README.