### PR TITLE
Fix branch name resolution for Jenkins

### DIFF
--- a/gitinfo.go
+++ b/gitinfo.go
@@ -106,7 +106,7 @@ func collectGitInfo() *Git {
 }
 
 func loadBranchFromEnv() string {
-	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH"}
+	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "BRANCH_NAME"}
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
 			return branch

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -20,6 +20,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
+				"BRANCH_NAME":          "jenkins-master",
 			},
 			"master",
 		},
@@ -31,6 +32,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
+				"BRANCH_NAME":          "jenkins-master",
 			},
 			"circle-master",
 		},
@@ -41,6 +43,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"CI_BRANCH":            "ci-master",
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
+				"BRANCH_NAME":          "jenkins-master",
 			},
 			"travis-master",
 		},
@@ -66,6 +69,13 @@ func TestLoadBranchFromEnv(t *testing.T) {
 			"wercker-master",
 		},
 		{
+			"only BRANCH_NAME defined",
+			map[string]string{
+				"BRANCH_NAME": "jenkins-master",
+			},
+			"jenkins-master",
+		},
+		{
 			"no branch var defined",
 			map[string]string{},
 			"",
@@ -81,7 +91,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 }
 
 func resetBranchEnvs(values map[string]string) {
-	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH"} {
+	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "BRANCH_NAME"} {
 		os.Unsetenv(envVar)
 	}
 	for k, v := range values {


### PR DESCRIPTION
Adding BRANCH_NAME as environment variable to be read as Jenkins multibranch pipelines export the branch name with this variable only. Otherwise, only HEAD will be returned as branch name.

See [Jenkins documentation](https://jenkins.io/doc/book/pipeline/multibranch/#additional-environment-variables) for more details.

In the meantime, one can simply export this variable to mitigate the issue:
`export GIT_BRANCH=$BRANCH_NAME`