### PR TITLE
feat(customJobId) add ability provided customJobId in any CI

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -243,8 +243,10 @@ func process() error {
 	//
 	// Initialize Job
 	//
+
+	// flags are never nil, so no nil check needed
 	jobId := *customJobId
-	if customJobId == nil || *customJobId == "" {
+	if *customJobId == "" {
 		jobId = os.Getenv("CUSTOM_JOB_ID")
 	} 
 

--- a/goveralls.go
+++ b/goveralls.go
@@ -43,21 +43,22 @@ func (a *Flags) Set(value string) error {
 }
 
 var (
-	extraFlags Flags
-	pkg        = flag.String("package", "", "Go package")
-	verbose    = flag.Bool("v", false, "Pass '-v' argument to 'go test' and output to stdout")
-	race       = flag.Bool("race", false, "Pass '-race' argument to 'go test'")
-	debug      = flag.Bool("debug", false, "Enable debug output")
-	coverprof  = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
-	covermode  = flag.String("covermode", "count", "sent as covermode argument to go test")
-	repotoken  = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls")
-	parallel   = flag.Bool("parallel", os.Getenv("COVERALLS_PARALLEL") != "", "Submit as parallel")
-	endpoint   = flag.String("endpoint", "https://coveralls.io", "Hostname to submit Coveralls data to")
-	service    = flag.String("service", "travis-ci", "The CI service or other environment in which the test suite was run. ")
-	shallow    = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
-	ignore     = flag.String("ignore", "", "Comma separated files to ignore")
-	insecure   = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
-	show       = flag.Bool("show", false, "Show which package is being tested")
+	extraFlags  Flags
+	pkg         = flag.String("package", "", "Go package")
+	verbose     = flag.Bool("v", false, "Pass '-v' argument to 'go test' and output to stdout")
+	race        = flag.Bool("race", false, "Pass '-race' argument to 'go test'")
+	debug       = flag.Bool("debug", false, "Enable debug output")
+	coverprof   = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
+	covermode   = flag.String("covermode", "count", "sent as covermode argument to go test")
+	repotoken   = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls")
+	parallel    = flag.Bool("parallel", os.Getenv("COVERALLS_PARALLEL") != "", "Submit as parallel")
+	endpoint    = flag.String("endpoint", "https://coveralls.io", "Hostname to submit Coveralls data to")
+	service     = flag.String("service", "travis-ci", "The CI service or other environment in which the test suite was run. ")
+	shallow     = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
+	ignore      = flag.String("ignore", "", "Comma separated files to ignore")
+	insecure    = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
+	show        = flag.Bool("show", false, "Show which package is being tested")
+	customJobId = flag.String("jobid", "", "Custom set job token")
 )
 
 // usage supplants package flag's Usage variable
@@ -242,17 +243,23 @@ func process() error {
 	//
 	// Initialize Job
 	//
-	var jobId string
-	if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
-		jobId = travisJobId
-	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
-		jobId = circleCiJobId
-	} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
-		jobId = appveyorJobId
-	} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
-		jobId = semaphoreJobId
-	} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
-		jobId = jenkinsJobId
+	jobId := *customJobId
+	if customJobId == nil || *customJobId == "" {
+		jobId = os.Getenv("CUSTOM_JOB_ID")
+	}
+
+	if jobId == "" {
+		if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
+			jobId = travisJobId
+		} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
+			jobId = circleCiJobId
+		} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
+			jobId = appveyorJobId
+		} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
+			jobId = semaphoreJobId
+		} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
+			jobId = jenkinsJobId
+		}
 	}
 
 	if *repotoken == "" {

--- a/goveralls.go
+++ b/goveralls.go
@@ -245,22 +245,23 @@ func process() error {
 	//
 
 	// flags are never nil, so no nil check needed
-	jobId := *customJobId
-	if jobId == "" {
-		if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
-			jobId = customJobIdEnv
-		} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
-			jobId = travisJobId
-		} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
-			jobId = circleCiJobId
-		} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
-			jobId = appveyorJobId
-		} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
-			jobId = semaphoreJobId
-		} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
-			jobId = jenkinsJobId
-		}
+	var jobId string
+	if *customJobId != "" {
+		jobId = *customJobId
+	} else if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
+		jobId = customJobIdEnv
+	} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
+		jobId = travisJobId
+	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
+		jobId = circleCiJobId
+	} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
+		jobId = appveyorJobId
+	} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
+		jobId = semaphoreJobId
+	} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
+		jobId = jenkinsJobId
 	}
+
 	
 
 	if *repotoken == "" {

--- a/goveralls.go
+++ b/goveralls.go
@@ -246,20 +246,20 @@ func process() error {
 
 	// flags are never nil, so no nil check needed
 	jobId := *customJobId
-	if *customJobId == "" {
-		jobId = os.Getenv("CUSTOM_JOB_ID")
-	} else if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
-		jobId = customJobIdEnv
-	} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
-		jobId = travisJobId
-	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
-		jobId = circleCiJobId
-	} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
-		jobId = appveyorJobId
-	} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
-		jobId = semaphoreJobId
-	} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
-		jobId = jenkinsJobId
+	if jobId == "" {
+		if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
+			jobId = customJobIdEnv
+		} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
+			jobId = travisJobId
+		} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
+			jobId = circleCiJobId
+		} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
+			jobId = appveyorJobId
+		} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
+			jobId = semaphoreJobId
+		} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
+			jobId = jenkinsJobId
+		}
 	}
 	
 

--- a/goveralls.go
+++ b/goveralls.go
@@ -248,21 +248,20 @@ func process() error {
 	jobId := *customJobId
 	if *customJobId == "" {
 		jobId = os.Getenv("CUSTOM_JOB_ID")
-	} 
-
-	if jobId == "" {
-		if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
-			jobId = travisJobId
-		} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
-			jobId = circleCiJobId
-		} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
-			jobId = appveyorJobId
-		} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
-			jobId = semaphoreJobId
-		} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
-			jobId = jenkinsJobId
-		}
+	} else if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
+		jobId = customJobIdEnv
+	} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
+		jobId = travisJobId
+	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
+		jobId = circleCiJobId
+	} else if appveyorJobId := os.Getenv("APPVEYOR_JOB_ID"); appveyorJobId != "" {
+		jobId = appveyorJobId
+	} else if semaphoreJobId := os.Getenv("SEMAPHORE_BUILD_NUMBER"); semaphoreJobId != "" {
+		jobId = semaphoreJobId
+	} else if jenkinsJobId := os.Getenv("BUILD_NUMBER"); jenkinsJobId != "" {
+		jobId = jenkinsJobId
 	}
+	
 
 	if *repotoken == "" {
 		repotoken = nil // remove the entry from json

--- a/goveralls.go
+++ b/goveralls.go
@@ -246,7 +246,7 @@ func process() error {
 	jobId := *customJobId
 	if customJobId == nil || *customJobId == "" {
 		jobId = os.Getenv("CUSTOM_JOB_ID")
-	}
+	} 
 
 	if jobId == "" {
 		if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {


### PR DESCRIPTION
addressed #122 

adds support for custom job ID via `goveralls -jobid=<JOBID>` or the env var `CUSTOM_JOB_ID`

Adds test to ensure correct job id is sent; as a note, this test is an example for how payloads can be checked for any other given test.