### PR TITLE
Add buildkite support through environment variables

### DIFF
--- a/gitinfo.go
+++ b/gitinfo.go
@@ -75,7 +75,7 @@ func collectGitInfo() *Git {
 }
 
 func loadBranchFromEnv() string {
-	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BRANCH_NAME"}
+	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"}
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
 			return branch

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -21,6 +21,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
 				"DRONE_BRANCH":         "drone-master",
+				"BUILDKITE_BRANCH":     "buildkite-master",
 				"BRANCH_NAME":          "jenkins-master",
 			},
 			"master",
@@ -34,6 +35,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
 				"DRONE_BRANCH":         "drone-master",
+				"BUILDKITE_BRANCH":     "buildkite-master",
 				"BRANCH_NAME":          "jenkins-master",
 			},
 			"circle-master",
@@ -46,6 +48,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 				"APPVEYOR_REPO_BRANCH": "appveyor-master",
 				"WERCKER_GIT_BRANCH":   "wercker-master",
 				"DRONE_BRANCH":         "drone-master",
+				"BUILDKITE_BRANCH":     "buildkite-master",
 				"BRANCH_NAME":          "jenkins-master",
 			},
 			"travis-master",
@@ -79,6 +82,13 @@ func TestLoadBranchFromEnv(t *testing.T) {
 			"jenkins-master",
 		},
 		{
+			"only BUILDKITE_BRANCH defined",
+			map[string]string{
+				"BUILDKITE_BRANCH": "buildkite-master",
+			},
+			"buildkite-master",
+		},
+		{
 			"only DRONE_BRANCH defined",
 			map[string]string{
 				"DRONE_BRANCH": "drone-master",
@@ -101,7 +111,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 }
 
 func resetBranchEnvs(values map[string]string) {
-	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BRANCH_NAME"} {
+	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"} {
 		os.Unsetenv(envVar)
 	}
 	for k, v := range values {

--- a/goveralls.go
+++ b/goveralls.go
@@ -255,6 +255,8 @@ func process() error {
 		jobId = jenkinsJobId
 	} else if droneBuildNumber := os.Getenv("DRONE_BUILD_NUMBER"); droneBuildNumber != "" {
 		jobId = droneBuildNumber
+	} else if buildkiteBuildNumber := os.Getenv("BUILDKITE_BUILD_NUMBER"); buildkiteBuildNumber != "" {
+		jobId = buildkiteBuildNumber
 	}
 
 	if *repotoken == "" {
@@ -274,6 +276,8 @@ func process() error {
 	} else if prNumber := os.Getenv("PULL_REQUEST_NUMBER"); prNumber != "" {
 		pullRequest = prNumber
 	} else if prNumber := os.Getenv("DRONE_PULL_REQUEST"); prNumber != "" {
+		pullRequest = prNumber
+	} else if prNumber := os.Getenv("BUILDKITE_PULL_REQUEST"); prNumber != "" {
 		pullRequest = prNumber
 	}
 


### PR DESCRIPTION
This PR adds support for default goveralls and gitinfo infromation from the expected buildkite environment variables for the branch name, build number and pull request number.