### PR TITLE
Fix Github Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ docs](https://docs.coveralls.io/parallel-build-webhook) for more details.
 There is no need to run `go test` separately, as `goveralls` runs the entire
 test suite.
 
+## Github Actions
+
+```yaml
+name: Quality
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+    - master
+jobs:
+  test:
+    name: Test with Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: Check out code
+      uses: actions/checkout@master
+    - name: Install dependencies
+      run: |
+        go mod download
+    - name: Run Unit tests
+      run: |
+        go test -race -covermode atomic -coverprofile=profile.cov ./...
+    - name: Send coverage
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        GO111MODULE=off go get github.com/mattn/goveralls
+        $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+```
+
 ## Travis CI
 
 ### GitHub Integration

--- a/gitinfo.go
+++ b/gitinfo.go
@@ -75,7 +75,7 @@ func collectGitInfo(ref string) *Git {
 }
 
 func loadBranchFromEnv() string {
-	varNames := []string{"GIT_BRANCH", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"}
+	varNames := []string{"GIT_BRANCH", "GITHUB_REF", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"}
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
 			return branch

--- a/goveralls.go
+++ b/goveralls.go
@@ -264,11 +264,12 @@ func process() error {
 	} else if buildkiteBuildNumber := os.Getenv("BUILDKITE_BUILD_NUMBER"); buildkiteBuildNumber != "" {
 		jobId = buildkiteBuildNumber
 	} else if githubSha := os.Getenv("GITHUB_SHA"); githubSha != "" {
+		githubShortSha := githubSha[0:9]
 		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-			number, _ := getGithubEvent()["number"].(float64)
-			jobId = fmt.Sprintf(`%s-PR-%d`, githubSha, int(number))
+			number := getGithubEvent()["number"].(float64)
+			jobId = fmt.Sprintf(`%s-PR-%d`, githubShortSha, int(number))
 		} else {
-			jobId = githubSha
+			jobId = githubShortSha
 		}
 	}
 
@@ -293,7 +294,7 @@ func process() error {
 	} else if prNumber := os.Getenv("BUILDKITE_PULL_REQUEST"); prNumber != "" {
 		pullRequest = prNumber
 	} else if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-		number, _ := getGithubEvent()["number"].(float64)
+		number := getGithubEvent()["number"].(float64)
 		pullRequest = strconv.Itoa(int(number))
 	}
 
@@ -308,9 +309,9 @@ func process() error {
 
 	commitRef := "HEAD"
 	if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-		ghPR, _ := getGithubEvent()["pull_request"].(map[string]interface{})
-		ghHead, _ := ghPR["head"].(map[string]interface{})
-		commitRef, _ = ghHead["sha"].(string)
+		ghPR := getGithubEvent()["pull_request"].(map[string]interface{})
+		ghHead := ghPR["head"].(map[string]interface{})
+		commitRef = ghHead["sha"].(string)
 	}
 
 	j := Job{


### PR DESCRIPTION
Fix issues from #143 

- When missing, service is set to `Github Action`
- Job id is shortened to 9 first chars
- Fix missing branch name in push event

A sample of result is available here: https://coveralls.io/github/jderusse/http-broadcast (check last 2 builds submited at 01 Nov 2019 09:32PM UTC)