### PR TITLE
custom job id and job number

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -60,6 +60,7 @@ var (
 	insecure    = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
 	show        = flag.Bool("show", false, "Show which package is being tested")
 	customJobId = flag.String("jobid", "", "Custom set job token")
+	jobNumber   = flag.String("jobnumber", "", "Custom set job number")
 )
 
 // usage supplants package flag's Usage variable
@@ -83,6 +84,7 @@ type SourceFile struct {
 type Job struct {
 	RepoToken          *string       `json:"repo_token,omitempty"`
 	ServiceJobId       string        `json:"service_job_id"`
+	ServiceJobNumber   string        `json:"service_job_number,omitempty"`
 	ServicePullRequest string        `json:"service_pull_request,omitempty"`
 	ServiceName        string        `json:"service_name"`
 	SourceFiles        []*SourceFile `json:"source_files"`
@@ -336,6 +338,7 @@ func process() error {
 	if jobId != "" {
 		j.ServiceJobId = jobId
 	}
+	j.ServiceJobNumber = *jobNumber
 
 	// Ignore files
 	if len(*ignore) > 0 {

--- a/goveralls.go
+++ b/goveralls.go
@@ -256,8 +256,8 @@ func process() error {
 	var jobId string
 	if *customJobId != "" {
 		jobId = *customJobId
-	} else if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
-		jobId = customJobIdEnv
+	} else if serviceJobId := os.Getenv("COVERALLS_SERVICE_JOB_ID"); serviceJobId != "" {
+		jobId = serviceJobId
 	} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
 		jobId = travisJobId
 	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {

--- a/goveralls.go
+++ b/goveralls.go
@@ -44,21 +44,22 @@ func (a *Flags) Set(value string) error {
 }
 
 var (
-	extraFlags Flags
-	pkg        = flag.String("package", "", "Go package")
-	verbose    = flag.Bool("v", false, "Pass '-v' argument to 'go test' and output to stdout")
-	race       = flag.Bool("race", false, "Pass '-race' argument to 'go test'")
-	debug      = flag.Bool("debug", false, "Enable debug output")
-	coverprof  = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
-	covermode  = flag.String("covermode", "count", "sent as covermode argument to go test")
-	repotoken  = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls")
-	parallel   = flag.Bool("parallel", os.Getenv("COVERALLS_PARALLEL") != "", "Submit as parallel")
-	endpoint   = flag.String("endpoint", "https://coveralls.io", "Hostname to submit Coveralls data to")
-	service    = flag.String("service", "", "The CI service or other environment in which the test suite was run. ")
-	shallow    = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
-	ignore     = flag.String("ignore", "", "Comma separated files to ignore")
-	insecure   = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
-	show       = flag.Bool("show", false, "Show which package is being tested")
+	extraFlags  Flags
+	pkg         = flag.String("package", "", "Go package")
+	verbose     = flag.Bool("v", false, "Pass '-v' argument to 'go test' and output to stdout")
+	race        = flag.Bool("race", false, "Pass '-race' argument to 'go test'")
+	debug       = flag.Bool("debug", false, "Enable debug output")
+	coverprof   = flag.String("coverprofile", "", "If supplied, use a go cover profile (comma separated)")
+	covermode   = flag.String("covermode", "count", "sent as covermode argument to go test")
+	repotoken   = flag.String("repotoken", os.Getenv("COVERALLS_TOKEN"), "Repository Token on coveralls")
+	parallel    = flag.Bool("parallel", os.Getenv("COVERALLS_PARALLEL") != "", "Submit as parallel")
+	endpoint    = flag.String("endpoint", "https://coveralls.io", "Hostname to submit Coveralls data to")
+	service     = flag.String("service", "", "The CI service or other environment in which the test suite was run. ")
+	shallow     = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
+	ignore      = flag.String("ignore", "", "Comma separated files to ignore")
+	insecure    = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
+	show        = flag.Bool("show", false, "Show which package is being tested")
+	customJobId = flag.String("jobid", "", "Custom set job token")
 )
 
 // usage supplants package flag's Usage variable
@@ -248,8 +249,14 @@ func process() error {
 	//
 	// Initialize Job
 	//
+
+	// flags are never nil, so no nil check needed
 	var jobId string
-	if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
+	if *customJobId != "" {
+		jobId = *customJobId
+	} else if customJobIdEnv := os.Getenv("CUSTOM_JOB_ID"); customJobIdEnv != "" {
+		jobId = customJobIdEnv
+	} else if travisJobId := os.Getenv("TRAVIS_JOB_ID"); travisJobId != "" {
 		jobId = travisJobId
 	} else if circleCiJobId := os.Getenv("CIRCLE_BUILD_NUM"); circleCiJobId != "" {
 		jobId = circleCiJobId


### PR DESCRIPTION
related to #122, and #123 

before adding the job number https://coveralls.io/builds/27070546
![before](https://user-images.githubusercontent.com/1157344/69108548-54220f80-0ab8-11ea-982a-5901afe44e1f.png)

after adding the job number https://coveralls.io/builds/27069677
![image](https://user-images.githubusercontent.com/1157344/69108598-7b78dc80-0ab8-11ea-8c44-27243df3b3f6.png)

Here is an example of configure for GitHub Actions.

https://github.com/shogo82148/go-sql-proxy/pull/35

https://github.com/shogo82148/go-sql-proxy/blob/bf53365379fe59e5cb5ddde6c54a04b79a81ae74/.github/workflows/go.yml#L32-L46
```yaml
    - name: Send coverage
      env:
        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      run: |
        GO111MODULE=off go get github.com/shogo82148/goveralls
        $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -parallel -jobid=$GITHUB_SHA -service=github

  finish:
    needs: test
    runs-on: ubuntu-latest
    steps:
      - name: finish
        env:
          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: curl -sS "https://coveralls.io/webhook" -d "repo_token=$COVERALLS_TOKEN&repo_name=$GITHUB_REPOSITORY&payload[build_num]=$GITHUB_SHA&payload[status]=done"
```