### PR TITLE
Remove the `sudo` in the travis example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ For a **public** github repository put below's `.travis.yml`.
 
 ```yml
 language: go
-sudo: false
 go:
   - tip
 before_install:
@@ -98,7 +97,6 @@ For a **private** github repository put below's `.travis.yml`. If you use **trav
 
 ```yml
 language: go
-sudo: false
 go:
   - tip
 before_install:


### PR DESCRIPTION
The key `sudo` has no effect anymore.

see https://config.travis-ci.com/ref/sudo