### PR TITLE
Use filepath.ToSlash for commonize test results across multiple platforms

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -207,10 +207,10 @@ func findRepositoryRoot(dir string) (string, bool) {
 
 func getCoverallsSourceFileName(name string) string {
 	if dir, ok := findRepositoryRoot(name); !ok {
-		return name
+		return filepath.ToSlash(name)
 	} else {
 		filename := strings.TrimPrefix(name, dir+string(os.PathSeparator))
-		return filename
+		return filepath.ToSlash(filename)
 	}
 }
 


### PR DESCRIPTION
We want to merge test results between multiple OSes on Coveralls, but the test results will be separated due to the difference of the path separator as following. (see. cmdutil\run.go and cmdutil/run.go)
https://coveralls.io/builds/27661502

How about using `filepath.ToSlash` for commonize test results.

ref. https://shogo82148.github.io/blog/2019/12/05/actions-goveralls/