### PR TITLE
fix resetBranchEnvs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/gitinfo.go
+++ b/gitinfo.go
@@ -74,8 +74,11 @@ func collectGitInfo(ref string) *Git {
 	return g
 }
 
+var varNames = [...]string{
+	"GIT_BRANCH", "GITHUB_REF", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME",
+}
+
 func loadBranchFromEnv() string {
-	varNames := []string{"GIT_BRANCH", "GITHUB_REF", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"}
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
 			return branch

--- a/gitinfo.go
+++ b/gitinfo.go
@@ -75,12 +75,23 @@ func collectGitInfo(ref string) *Git {
 }
 
 var varNames = [...]string{
-	"GIT_BRANCH", "GITHUB_REF", "CIRCLE_BRANCH", "TRAVIS_BRANCH", "CI_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME",
+	"GIT_BRANCH",
+
+	// https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables
+	"GITHUB_HEAD_REF", "GITHUB_REF",
+
+	"CIRCLE_BRANCH", "TRAVIS_BRANCH",
+	"CI_BRANCH", "APPVEYOR_REPO_BRANCH",
+	"WERCKER_GIT_BRANCH", "DRONE_BRANCH",
+	"BUILDKITE_BRANCH", "BRANCH_NAME",
 }
 
 func loadBranchFromEnv() string {
 	for _, varName := range varNames {
 		if branch := os.Getenv(varName); branch != "" {
+			if varName == "GITHUB_REF" {
+				return strings.TrimPrefix(branch, "refs/heads/")
+			}
 			return branch
 		}
 	}

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -96,6 +96,13 @@ func TestLoadBranchFromEnv(t *testing.T) {
 			"drone-master",
 		},
 		{
+			"GitHub Action push event",
+			map[string]string{
+				"GITHUB_REF": "refs/heads/github-master",
+			},
+			"github-master",
+		},
+		{
 			"no branch var defined",
 			map[string]string{},
 			"",

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -111,7 +111,7 @@ func TestLoadBranchFromEnv(t *testing.T) {
 }
 
 func resetBranchEnvs(values map[string]string) {
-	for _, envVar := range []string{"CI_BRANCH", "CIRCLE_BRANCH", "GIT_BRANCH", "TRAVIS_BRANCH", "APPVEYOR_REPO_BRANCH", "WERCKER_GIT_BRANCH", "DRONE_BRANCH", "BUILDKITE_BRANCH", "BRANCH_NAME"} {
+	for _, envVar := range varNames {
 		os.Unsetenv(envVar)
 	}
 	for k, v := range values {


### PR DESCRIPTION
fix https://github.com/mattn/goveralls/commit/b2bbf7ba3ef2cff3f574aa2f3133676b1807af3c/checks?check_suite_id=364425408#step:6:6

>     gitinfo_test.go:108: all except GIT_BRANCH: wrong branch returned. Expected "circle-master", but got "refs/heads/master"
>     gitinfo_test.go:108: all except GIT_BRANCH and CIRCLE_BRANCH: wrong branch returned. Expected "travis-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only CI_BRANCH defined: wrong branch returned. Expected "ci-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only APPVEYOR_REPO_BRANCH defined: wrong branch returned. Expected "appveyor-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only WERCKER_GIT_BRANCH defined: wrong branch returned. Expected "wercker-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only BRANCH_NAME defined: wrong branch returned. Expected "jenkins-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only BUILDKITE_BRANCH defined: wrong branch returned. Expected "buildkite-master", but got "refs/heads/master"
>     gitinfo_test.go:108: only DRONE_BRANCH defined: wrong branch returned. Expected "drone-master", but got "refs/heads/master"
>     gitinfo_test.go:108: no branch var defined: wrong branch returned. Expected "", but got "refs/heads/master"
> 