### PR TITLE
Enable passing of build tags

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"go/build"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 	"time"
 
 	"golang.org/x/tools/cover"
+	"golang.org/x/tools/go/buildutil"
 )
 
 /*
@@ -68,6 +70,10 @@ var (
 
 	parallelFinish = flag.Bool("parallel-finish", false, "finish parallel test")
 )
+
+func init() {
+	flag.Var((*buildutil.TagsFlag)(&build.Default.BuildTags), "tags", buildutil.TagsFlagDoc)
+}
 
 // usage supplants package flag's Usage variable
 var usage = func() {


### PR DESCRIPTION
coverall is currently unable to find files that are built conditionally
using build tags. The problem stems from use of the `build.Import`
function which in turn relies on the `build.Default` context. There's
currently no way to configure the `BuildFlags` in this context.

This commit adds a call to `flag.Var()` to ensure that the default
context is configured according to a `-tags` option the same way that
many other go tools do this. See example at
https://godoc.org/golang.org/x/tools/go/buildutil#TagsFlag

Closes #46