### PR TITLE
fix GITHUB ACTION RUN button

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -338,14 +338,8 @@ func process() error {
 		jobID = buildkiteBuildNumber
 	} else if codeshipjobID := os.Getenv("CI_BUILD_ID"); codeshipjobID != "" {
 		jobID = codeshipjobID
-	} else if githubSHA := os.Getenv("GITHUB_SHA"); githubSHA != "" {
-		githubShortSha := githubSHA[0:9]
-		if os.Getenv("GITHUB_EVENT_NAME") == "pull_request" {
-			number := githubEvent["number"].(float64)
-			jobID = fmt.Sprintf(`%s-PR-%d`, githubShortSha, int(number))
-		} else {
-			jobID = githubShortSha
-		}
+	} else if githubRunID := os.Getenv("GITHUB_RUN_ID"); githubRunID != "" {
+		jobID = githubRunID
 	}
 
 	if *parallelFinish {


### PR DESCRIPTION
There are GITHUB ACTION RUN buttons on build pages (e.g. https://coveralls.io/builds/30958188 ), but their url is broken.

![image](https://user-images.githubusercontent.com/1157344/82757692-1f9f5f80-9e1d-11ea-8503-3a74f0d4e97b.png)

- current url: https://github.com/shogo82148/actions-goveralls/actions/runs/00d2d64b9-PR-106
- expected url: https://github.com/shogo82148/actions-goveralls/actions/runs/111929154
