### PR TITLE
Introduce flag name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           go install .
         working-directory: src/github.com/mattn/goveralls
       - name: test
-        run: goveralls -service=github -parallel -flagname="Unit-$GITHUB_RUN_NUMBER"
+        run: goveralls -service=github -parallel -flagname="Unit-${{ matrix.os }}-Go-${{ matrix.go }}"
         working-directory: src/github.com/mattn/goveralls
         env:
           COVERALLS_TOKEN: ${{ github.token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           go install .
         working-directory: src/github.com/mattn/goveralls
       - name: test
-        run: goveralls -service=github -parallel
+        run: goveralls -service=github -parallel -flagname="Unit-$GITHUB_RUN_NUMBER"
         working-directory: src/github.com/mattn/goveralls
         env:
           COVERALLS_TOKEN: ${{ github.token }}

--- a/goveralls.go
+++ b/goveralls.go
@@ -67,6 +67,7 @@ var (
 	show        = flag.Bool("show", false, "Show which package is being tested")
 	customJobID = flag.String("jobid", "", "Custom set job token")
 	jobNumber   = flag.String("jobnumber", "", "Custom set job number")
+	flagName    = flag.String("flagname", os.Getenv("COVERALLS_FLAG_NAME"), "Job flag name, e.g. \"Unit\", \"Functional\", or \"Integration\". Will be shown in the Coveralls UI.")
 
 	parallelFinish = flag.Bool("parallel-finish", false, "finish parallel test")
 )
@@ -99,6 +100,7 @@ type Job struct {
 	ServiceJobNumber   string        `json:"service_job_number,omitempty"`
 	ServicePullRequest string        `json:"service_pull_request,omitempty"`
 	ServiceName        string        `json:"service_name"`
+	FlagName           string        `json:"flag_name,omitempty"`
 	SourceFiles        []*SourceFile `json:"source_files"`
 	Parallel           *bool         `json:"parallel,omitempty"`
 	Git                *Git          `json:"git,omitempty"`
@@ -398,6 +400,7 @@ func process() error {
 		Git:                collectGitInfo(head),
 		SourceFiles:        sourceFiles,
 		ServiceName:        *service,
+		FlagName:           *flagName,
 	}
 
 	// Only include a job ID if it's known, otherwise, Coveralls looks


### PR DESCRIPTION
From read me of https://github.com/coverallsapp/github-action

> flag-name
> optional (unique required if parallel)
> Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.
