### PR TITLE
Introduce a new option -uploadsource

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -65,6 +65,7 @@ var (
 	shallow       = flag.Bool("shallow", false, "Shallow coveralls internal server errors")
 	ignore        = flag.String("ignore", "", "Comma separated files to ignore")
 	insecure      = flag.Bool("insecure", false, "Set insecure to skip verification of certificates")
+	uploadSource  = flag.Bool("uploadsource", true, "Read local source and upload it to coveralls")
 	show          = flag.Bool("show", false, "Show which package is being tested")
 	customJobID   = flag.String("jobid", "", "Custom set job token")
 	jobNumber     = flag.String("jobnumber", "", "Custom set job number")

--- a/usage_lt1.15_test.go
+++ b/usage_lt1.15_test.go
@@ -17,7 +17,7 @@ func TestUsage(t *testing.T) {
 	b, err := cmd.CombinedOutput()
 	runtime.Version()
 	if err == nil {
-		t.Fatal("Expected exit code 1 bot 0")
+		t.Fatal("Expected exit code 1 got 0")
 	}
 	s := strings.Split(string(b), "\n")[0]
 	if !strings.HasPrefix(s, "Usage: goveralls ") {


### PR DESCRIPTION
This PR introduces a new option `-uploadsource=true` which allows to disable uploading source code to coveralls.io.

Additionally it fixes panics due to local files having less lines than what is reported on the coverage profile since reading the count of lines from the source is not needed anymore (example: #86).

Existing behaviour is preserved because the default value is `true`.

Other changes:
* return error instead of using `log.Fatal` in a couple functions