### PR TITLE
Allow debugging webhook request

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -251,6 +251,13 @@ func processParallelFinish(jobID, token string) error {
 	params.Set("payload[build_num]", jobID)
 	params.Set("payload[status]", "done")
 	res, err := http.PostForm(*endpoint+"/webhook", params)
+	if *debug {
+		if token != "" {
+			params.Set("repo_token", "*******")
+		}
+		log.Printf("Posted webhook data: %q", params.Encode())
+	}
+
 	if err != nil {
 		return err
 	}
@@ -447,6 +454,11 @@ func process() error {
 	}
 
 	if *debug {
+		j := j
+		if j.RepoToken != nil && *j.RepoToken != "" {
+			s := "*******"
+			j.RepoToken = &s
+		}
 		b, err := json.MarshalIndent(j, "", "  ")
 		if err != nil {
 			return err

--- a/goveralls.go
+++ b/goveralls.go
@@ -298,7 +298,7 @@ func process() error {
 	flag.Parse()
 	if len(flag.Args()) > 0 {
 		flag.Usage()
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	//


### PR DESCRIPTION
This PR adds some code to allow debugging webhook request; this will allow better troubleshooting for issues like #171 and #124.

The repo token is masked in the debug output and I modified the existing log line for the only other POST to also mask the repo token.