### PR TITLE
Add Go 1.14 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - '1.11'
   - '1.12'
   - '1.13'
+  - '1.14'
 before_install:
   - go get ./...
   - go install .


### PR DESCRIPTION
Let's add Go 1.14 builds as well (see #182).