### PR TITLE
Only build on Travis with latest Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: go
 go:
-  - '1.7'
-  - '1.8'
-  - '1.9'
-  - '1.10'
-  - '1.11'
-  - '1.12'
-  - '1.13'
+  - '1.x'
 before_install:
   - go get ./...
   - go install .


### PR DESCRIPTION
As a follow-up to [this comment](https://github.com/mattn/goveralls/pull/185#issuecomment-720711537) I propose to limit the Travis CI builds to only the latest version of Go.