### PR TITLE
Parallelize all tests, remove multiple binaries creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: src/github.com/mattn/goveralls
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: build
         run: |
           go get ./...
@@ -53,6 +54,8 @@ jobs:
         with:
           go-version: '1.x'
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: finish
         run: |
           go run github.com/mattn/goveralls -parallel-finish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
         working-directory: src/github.com/mattn/goveralls
         env:
           COVERALLS_TOKEN: ${{ github.token }}
+          GIT_BRANCH: ${{ github.head_ref }}
 
   finish:
     needs: test
@@ -61,3 +62,4 @@ jobs:
           go run github.com/mattn/goveralls -parallel-finish
         env:
           COVERALLS_TOKEN: ${{ github.token }}
+          GIT_BRANCH: ${{ github.head_ref }}

--- a/gitinfo_test.go
+++ b/gitinfo_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestLoadBranchFromEnv(t *testing.T) {
+	t.Parallel()
+
 	var tests = []struct {
 		testCase       string
 		envs           map[string]string

--- a/gocover_test.go
+++ b/gocover_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestMergeProfs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		in   [][]*cover.Profile
 		want []*cover.Profile

--- a/goveralls.go
+++ b/goveralls.go
@@ -81,8 +81,7 @@ func init() {
 
 // usage supplants package flag's Usage variable
 var usage = func() {
-	cmd := os.Args[0]
-	// fmt.Fprintf(os.Stderr, "Usage of %s:\n", cmd)
+	cmd := filepath.Base(os.Args[0])
 	s := "Usage: %s [options]\n"
 	fmt.Fprintf(os.Stderr, s, cmd)
 	flag.PrintDefaults()

--- a/usage_ge1.15_test.go
+++ b/usage_ge1.15_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -11,16 +10,20 @@ import (
 )
 
 func TestUsage(t *testing.T) {
-	tmp := prepareTest(t)
-	defer os.RemoveAll(tmp)
-	cmd := exec.Command("goveralls", "-h")
+	t.Parallel()
+
+	cmd := exec.Command(goverallsTestBin, "-h")
 	b, err := cmd.CombinedOutput()
 	runtime.Version()
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := strings.Split(string(b), "\n")[0]
-	if !strings.HasPrefix(s, "Usage: goveralls ") {
-		t.Fatalf("Expected %v, but %v", "Usage: ", s)
+	expectedPrefix := "Usage: goveralls"
+	if runtime.GOOS == "windows" {
+		expectedPrefix += ".exe"
+	}
+	if !strings.HasPrefix(s, expectedPrefix) {
+		t.Fatalf("Expected prefix %q, but got %q", expectedPrefix, s)
 	}
 }

--- a/usage_lt1.15_test.go
+++ b/usage_lt1.15_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -11,16 +10,20 @@ import (
 )
 
 func TestUsage(t *testing.T) {
-	tmp := prepareTest(t)
-	defer os.RemoveAll(tmp)
-	cmd := exec.Command("goveralls", "-h")
+	t.Parallel()
+
+	cmd := exec.Command(goverallsTestBin, "-h")
 	b, err := cmd.CombinedOutput()
 	runtime.Version()
 	if err == nil {
 		t.Fatal("Expected exit code 1 got 0")
 	}
 	s := strings.Split(string(b), "\n")[0]
-	if !strings.HasPrefix(s, "Usage: goveralls ") {
-		t.Fatalf("Expected %v, but %v", "Usage: ", s)
+	expectedPrefix := "Usage: goveralls"
+	if runtime.GOOS == "windows" {
+		expectedPrefix += ".exe"
+	}
+	if !strings.HasPrefix(s, expectedPrefix) {
+		t.Fatalf("Expected prefix %q, but got %q", expectedPrefix, s)
 	}
 }


### PR DESCRIPTION
This PR parallelizes all tests and removes the creation of one binary for each test; additionally, the broken and commented-out test `TestGoveralls` is removed. This test would upload to coveralls.io so I think it should not be an unit test at all.

The integration with coveralls.io is covered by the steps in the current GitHub Workflow.