### PR TITLE
Update Coveralls documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ test:
     - /home/ubuntu/.go_workspace/bin/goveralls -coverprofile=/home/ubuntu/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
 ```
 
-For more information, See https://coveralls.zendesk.com/hc/en-us/articles/201342809-Go
+For more information, See https://docs.coveralls.io/go
 
 ## Semaphore
 


### PR DESCRIPTION
The old link was NotFound, so I updated it.