### PR TITLE
Reduce build.Import calls when importing files from relative root

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,7 @@ jobs:
           - macos-latest
           - windows-latest
         go:
-          - '1.7'  # minimum version that macos-latest supports
-          - '1.10' # last version that doesn't support go modules
-          - '1.11' # first version that supports go modules
-          - '1.x'  # latest version
+          - '1.16'  # latest version
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ jobs:
           - macos-latest
           - windows-latest
         go:
-          - '1.16'  # latest version
+          - '1.7'  # minimum version that macos-latest supports
+          - '1.10' # last version that doesn't support go modules
+          - '1.11' # first version that supports go modules
+          - '1.x'  # latest version
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 /goveralls
+/vendor

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mattn/goveralls
 
 go 1.11
 
-require golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375
+require (
+	golang.org/x/mod v0.2.0
+	golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375
+)

--- a/gocover.go
+++ b/gocover.go
@@ -119,7 +119,7 @@ func toSF(profs []*cover.Profile) ([]*SourceFile, error) {
 	}
 	modPath := filepath.Join(rootDirectory, "go.mod")
 	rootPackage := ""
-	if content, err := os.ReadFile(modPath); err == nil {
+	if content, err := ioutil.ReadFile(modPath); err == nil {
 		rootPackage = modfile.ModulePath(content)
 	}
 


### PR DESCRIPTION
Fixes lengthy uploads when used from repositories with lots of Go files.

This reduced our goveralls time from ~2m to ~8s.