### PR TITLE
shallow 405 Method Not Allowed in process()

### DIFF
--- a/goveralls.go
+++ b/goveralls.go
@@ -513,9 +513,20 @@ func process() error {
 		return fmt.Errorf("unable to read response body from coveralls: %s", err)
 	}
 
-	if res.StatusCode >= http.StatusInternalServerError && *shallow {
-		fmt.Println("coveralls server failed internally")
-		return nil
+	if *shallow {
+		if res.StatusCode >= http.StatusInternalServerError {
+			fmt.Println("coveralls server failed internally")
+			return nil
+		}
+
+		// XXX: It looks that Coveralls is under maintenance.
+		// Coveralls serves the maintenance page as a static HTML hosting,
+		// and the maintenance page doesn't accept POST method.
+		// See https://github.com/mattn/goveralls/issues/204
+		if res.StatusCode == http.StatusMethodNotAllowed {
+			fmt.Println("it looks that Coveralls is under maintenance. visit https://status.coveralls.io/")
+			return nil
+		}
 	}
 
 	if res.StatusCode != 200 {


### PR DESCRIPTION
I did it in `processParallelFinish()` in https://github.com/mattn/goveralls/pull/205
However I forgot to do it in `process()`.
