### PR TITLE
Update GitHub Actions to Use Latest Stable Versions and Improve Coverage Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
       - run: go version
@@ -42,11 +42,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
       - name: finish
         run: |
           go run github.com/mattn/goveralls -parallel-finish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
           - macos-latest
           - windows-latest
         go:
-          - '1.13' # minimum version
+          - '1.16' # minimum version
           - 'oldstable'
           - 'stable'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: misspell
         uses: reviewdog/action-misspell@v1
         with:

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ jobs:
     name: Test with Coverage
     runs-on: ubuntu-latest
     steps:
+     - name: Check out code
+      uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.16'
-    - name: Check out code
-      uses: actions/checkout@v2
+        go-version: 'stable'
     - name: Install dependencies
       run: |
         go mod download


### PR DESCRIPTION
- Updated workflow to use `actions/checkout@v4` and `actions/setup-go@v5` for better support and long-term maintenance.
- Changed Go version setting to `'stable'` to automatically track the latest stable release.
- Ensured correct order of steps: `checkout` runs before `setup-go`.

This change improves CI stability, aligns with best practices, and future-proofs the Go setup.

